### PR TITLE
Remove minimum-scale=1 from meta viewport since AMP no longer requires it

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,7 +14,7 @@
 <html <?php language_attributes(); ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, <?php if ( twentynineteen_is_amp_endpoint() ) { echo 'minimum-scale=1'; } ?>" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<link rel="profile" href="https://gmpg.org/xfn/11" />
 	<?php wp_head(); ?>
 </head>


### PR DESCRIPTION
See https://github.com/ampproject/amphtml/pull/19129