### PR TITLE
Fix AMP validation errors regarding amp-accordion and missing role=button

### DIFF
--- a/classes/class-twentynineteen-walker-amp-menu.php
+++ b/classes/class-twentynineteen-walker-amp-menu.php
@@ -155,7 +155,6 @@ class TwentyNineteen_AMP_Menu_Walker extends Walker_Nav_Menu {
 		$output .= '<li class="menu-item-has-children"><amp-accordion><section>';
 
 		$this->accordion_started = TRUE;
-		$this->enqueue_accordion = TRUE;
 	}
 
 

--- a/classes/class-twentynineteen-walker-amp-menu.php
+++ b/classes/class-twentynineteen-walker-amp-menu.php
@@ -121,9 +121,9 @@ class TwentyNineteen_AMP_Menu_Walker extends Walker_Nav_Menu {
 		if ( $this->has_children ) {
 			$this->start_accordion( $output, $depth );
 
-			$output .= '<li ' . $class_names . '>';
+			$output .= '<h2 ' . $class_names . '>';
 			$output .= $this->get_anchor_tag( $item, $depth, $args, $id );
-			$output .= '</li>';
+			$output .= '</h2>';
 
 			$this->start_accordion_child_wrapper( $output, $depth );
 

--- a/functions.php
+++ b/functions.php
@@ -275,23 +275,6 @@ function twentynineteen_scripts() {
 add_action( 'wp_enqueue_scripts', 'twentynineteen_scripts' );
 
 /**
- * Enqueue AMP scripts.
- */
-function twentynineteen_amp_scripts( $data ) {
-
-	$custom_component_scripts = array(
-		'amp-sidebar'      => 'https://cdn.ampproject.org/v0/amp-sidebar-0.1.js',
-		'amp-accordion'    => 'https://cdn.ampproject.org/v0/amp-accordion-0.1.js',
-		'amp-bind'         => 'https://cdn.ampproject.org/v0/amp-bind-0.1.js',
-		'amp-live-list'    => 'https://cdn.ampproject.org/v0/amp-live-list-0.1.js'
-	);
-	$data['component_scripts'] = array_merge( $data['component_scripts'], $custom_component_scripts );
-	return $data;
-
-}
-add_action( 'amp_post_template_data', 'twentynineteen_amp_scripts' );
-
-/**
  * Fix skip link focus in IE11.
  *
  * This does not enqueue the script because it is tiny and because it is only for IE11,

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -484,7 +484,7 @@ function twentynineteen_render_amp_nav() {
 function twentynineteen_add_back_link_amp_menu( $items, $args ) {
 	if ( $args->theme_location == 'menu-1' ) {
 		// Add a close link as the first menu item.
-		$close = '<li on="tap:site-navigation.close" class="mobile-amp-nav-menu-item" tabindex="-1"><button class="menu-item-link-return">%1$s%2$s</button></li>';
+		$close = '<li on="tap:site-navigation.close" role="button" class="mobile-amp-nav-menu-item" tabindex="-1"><button class="menu-item-link-return">%1$s%2$s</button></li>';
 
 		$close = sprintf( $close,
 			twentynineteen_get_icon_svg( 'chevron_left', 24 ),


### PR DESCRIPTION
I noticed a couple AMP validation errors:

* `li` element not allowed as child of `amp-accordion`. Fixed by replacing with `h2`.
* Missing `role=button` on `li` element that has an `on` attribute added.

Also, filtering `amp_post_template_data` to add scripts is not needed in AMP paired/native mode since the AMP plugin automatically determines which AMP component scripts need to be added.